### PR TITLE
Title: Add playback speed control and carousel UX improvements

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -396,7 +396,7 @@ body {
 /* ===== CONTROLS BAR — bottom center ===== */
 .hero-controls {
   position: absolute;
-  bottom: -4px;
+  bottom: 0px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 10;
@@ -406,7 +406,7 @@ body {
   background: rgba(77, 0, 10, 0.65);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  padding: 10px 20px;
+  padding: 8px;
   border-radius: 40px;
   border: 1px solid rgba(245, 184, 89, 0.25);
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -975,6 +975,26 @@ body {
 .site-main { margin: 0; padding: 0; }
 .site-header { display: none; }
 
+/* ===== RESPONSIVE CAROUSEL SPACING ===== */
+/* Narrow desktop / tablet: push side-peek cards apart to avoid crowding */
+@media screen and (max-width: 600px) {
+  :root { --slide-pct: 80; }
+  .carousel-viewport { padding-left: 16px; padding-right: 16px; }
+}
+
+/* Wide screens: shrink slide % so side-peek cards stay visible */
+@media screen and (min-width: 1000px) {
+  :root { --slide-pct: 56; }
+}
+
+@media screen and (min-width: 1200px) {
+  :root { --slide-pct: 48; }
+}
+
+@media screen and (min-width: 1400px) {
+  :root { --slide-pct: 42; }
+}
+
 /* ===== MOBILE OVERRIDES ===== */
 body.mobile-device {
   --slide-pct: 92;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -89,6 +89,11 @@ body {
   opacity: 0.5;
 }
 
+/* Inactive slides are clickable to navigate */
+.carousel-slide:not(.is-active) .slide-card {
+  cursor: pointer;
+}
+
 .carousel-slide.is-active .slide-card {
   transform: scale(1);
   opacity: 1;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -439,6 +439,27 @@ body {
 .ctrl-playpause.is-paused .pp-play { display: inline; }
 .ctrl-playpause.is-paused .pp-pause { display: none; }
 
+/* Speed control button — pill shape with text label */
+.ctrl-speed {
+  border-radius: 20px;
+  width: auto;
+  min-width: 40px;
+  padding: 0 10px;
+}
+
+.speed-label {
+  font-family: 'Kufam', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--flour);
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.ctrl-speed.is-fast .speed-label {
+  color: var(--wheat);
+}
+
 .card-ctrl:disabled {
   opacity: 0.3;
   cursor: default;
@@ -994,6 +1015,8 @@ body.mobile-device {
 .mobile-device .card-header-controls { gap: 6px; }
 .mobile-device .card-ctrl { width: 32px; height: 32px; }
 .mobile-device .card-ctrl svg { width: 14px; height: 14px; }
+.mobile-device .ctrl-speed { width: auto; min-width: 32px; padding: 0 7px; }
+.mobile-device .speed-label { font-size: 10px; }
 .mobile-device .card-footer { padding: 8px 10px; }
 .mobile-device .card-footer-subtitle { font-size: 12px; }
 .mobile-device .card-footer-brand { font-size: 10px; }

--- a/index.md
+++ b/index.md
@@ -644,6 +644,13 @@ function onYouTubeIframeAPIReady() {
     });
   });
 
+  // Reposition carousel on resize (picks up responsive --slide-pct changes)
+  var resizeTimer;
+  window.addEventListener('resize', function() {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function() { goTo(currentSlide); }, 150);
+  });
+
   // Expose for external use
   window._carouselGoTo = goTo;
   window._updatePulse = updatePulse;

--- a/index.md
+++ b/index.md
@@ -23,6 +23,9 @@ title: Home
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
               </button>
+              <button class="card-ctrl ctrl-speed" data-slide="0" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
+              </button>
               <button class="card-ctrl card-mute is-muted" data-slide="0" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
                 <svg class="sound-icon-on" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>
@@ -48,6 +51,9 @@ title: Home
               <button class="card-ctrl ctrl-playpause" data-slide="1" aria-label="Play/Pause">
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+              </button>
+              <button class="card-ctrl ctrl-speed" data-slide="1" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
               </button>
               <button class="card-ctrl card-mute is-muted" data-slide="1" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
@@ -75,6 +81,9 @@ title: Home
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
               </button>
+              <button class="card-ctrl ctrl-speed" data-slide="2" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
+              </button>
               <button class="card-ctrl card-mute is-muted" data-slide="2" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
                 <svg class="sound-icon-on" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>
@@ -100,6 +109,9 @@ title: Home
               <button class="card-ctrl ctrl-playpause" data-slide="3" aria-label="Play/Pause">
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+              </button>
+              <button class="card-ctrl ctrl-speed" data-slide="3" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
               </button>
               <button class="card-ctrl card-mute is-muted" data-slide="3" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
@@ -134,6 +146,9 @@ title: Home
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
               </button>
+              <button class="card-ctrl ctrl-speed" disabled aria-label="Playback speed">
+                <span class="speed-label">1x</span>
+              </button>
               <button class="card-ctrl card-mute is-muted" data-slide="4" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
                 <svg class="sound-icon-on" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>
@@ -159,6 +174,9 @@ title: Home
               <button class="card-ctrl ctrl-playpause" data-slide="5" aria-label="Play/Pause">
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+              </button>
+              <button class="card-ctrl ctrl-speed" data-slide="5" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
               </button>
               <button class="card-ctrl card-mute is-muted" data-slide="5" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
@@ -186,6 +204,9 @@ title: Home
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
               </button>
+              <button class="card-ctrl ctrl-speed" data-slide="6" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
+              </button>
               <button class="card-ctrl card-mute is-muted" data-slide="6" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
                 <svg class="sound-icon-on" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>
@@ -212,6 +233,9 @@ title: Home
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
               </button>
+              <button class="card-ctrl ctrl-speed" data-slide="7" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
+              </button>
               <button class="card-ctrl card-mute is-muted" data-slide="7" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
                 <svg class="sound-icon-on" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M15.54 8.46a5 5 0 010 7.07"/></svg>
@@ -237,6 +261,9 @@ title: Home
               <button class="card-ctrl ctrl-playpause" data-slide="8" aria-label="Play/Pause">
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+              </button>
+              <button class="card-ctrl ctrl-speed" data-slide="8" aria-label="Playback speed">
+                <span class="speed-label">1x</span>
               </button>
               <button class="card-ctrl card-mute is-muted" data-slide="8" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
@@ -270,6 +297,9 @@ title: Home
               <button class="card-ctrl ctrl-playpause is-paused" disabled aria-label="Play/Pause">
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+              </button>
+              <button class="card-ctrl ctrl-speed" disabled aria-label="Playback speed">
+                <span class="speed-label">1x</span>
               </button>
               <button class="card-ctrl card-mute is-muted" data-slide="9" aria-label="Toggle sound">
                 <svg class="sound-icon-muted" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg>
@@ -365,6 +395,8 @@ var players = {};
 var globalMuted = true;
 var currentSlide = 0;
 var slidePlaying = {};  // per-slide play state
+var globalSpeed = 1;
+var speedOptions = [1, 1.25, 1.5, 1.75, 2];
 
 function onYouTubeIframeAPIReady() {
   var videoSlides = document.querySelectorAll('.carousel-slide[data-video-id]');
@@ -392,6 +424,7 @@ function onYouTubeIframeAPIReady() {
       events: {
         onReady: function(e) {
           if (isFirst) {
+            e.target.setPlaybackRate(globalSpeed);
             e.target.playVideo();
             slidePlaying[idx] = true;
           }
@@ -474,6 +507,7 @@ function onYouTubeIframeAPIReady() {
     if (players[currentSlide] && players[currentSlide].playVideo) {
       try {
         if (globalMuted) { players[currentSlide].mute(); } else { players[currentSlide].unMute(); }
+        players[currentSlide].setPlaybackRate(globalSpeed);
         players[currentSlide].playVideo();
         slidePlaying[currentSlide] = true;
       } catch(e) {}
@@ -567,6 +601,37 @@ function onYouTubeIframeAPIReady() {
       // Sync all connect audio elements mute state
       document.querySelectorAll('.connect-audio').forEach(function(a) { a.muted = globalMuted; });
       updatePulse(currentSlide);
+    });
+  });
+
+  // ===== Playback speed control =====
+  function formatSpeed(s) {
+    return s % 1 === 0 ? s + 'x' : s + 'x';
+  }
+
+  function syncSpeedLabels() {
+    var label = formatSpeed(globalSpeed);
+    document.querySelectorAll('.ctrl-speed').forEach(function(btn) {
+      var span = btn.querySelector('.speed-label');
+      if (span) span.textContent = label;
+      btn.classList.toggle('is-fast', globalSpeed !== 1);
+    });
+  }
+
+  document.querySelectorAll('.ctrl-speed').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var currentIdx = speedOptions.indexOf(globalSpeed);
+      globalSpeed = speedOptions[(currentIdx + 1) % speedOptions.length];
+
+      // Apply to all active YouTube players
+      Object.keys(players).forEach(function(key) {
+        var p = players[key];
+        if (p && p.setPlaybackRate) {
+          try { p.setPlaybackRate(globalSpeed); } catch(e) {}
+        }
+      });
+
+      syncSpeedLabels();
     });
   });
 

--- a/index.md
+++ b/index.md
@@ -439,6 +439,13 @@ function onYouTubeIframeAPIReady() {
           if (e.data === YT.PlayerState.ENDED) {
             players[idx].playVideo();
           }
+          // Trigger pulse when playback actually starts or pauses
+          if (e.data === YT.PlayerState.PLAYING || e.data === YT.PlayerState.PAUSED) {
+            slidePlaying[idx] = (e.data === YT.PlayerState.PLAYING);
+            if (idx === currentSlide && window._updatePulse) {
+              window._updatePulse(idx);
+            }
+          }
         }
       }
     });
@@ -483,7 +490,12 @@ function onYouTubeIframeAPIReady() {
     if (ppBtn && !ppBtn.disabled && !slidePlaying[idx]) {
       ppBtn.classList.add('ctrl-pulse');
     } else if (muteBtn && globalMuted && slidePlaying[idx]) {
-      muteBtn.classList.add('ctrl-pulse');
+      // Only pulse mute after video is actually playing (not just buffering)
+      var p = players[idx];
+      var actuallyPlaying = !isVideoSlide || (p && p.getPlayerState && p.getPlayerState() === YT.PlayerState.PLAYING);
+      if (actuallyPlaying) {
+        muteBtn.classList.add('ctrl-pulse');
+      }
     }
   }
 

--- a/index.md
+++ b/index.md
@@ -546,6 +546,14 @@ function onYouTubeIframeAPIReady() {
     });
   });
 
+  // Click a side-peek slide to bring it into focus
+  slides.forEach(function(slide) {
+    slide.addEventListener('click', function() {
+      var idx = parseInt(this.getAttribute('data-index'));
+      if (idx !== currentSlide) goTo(idx);
+    });
+  });
+
   // Swipe support
   var startX = 0;
   var viewport = document.querySelector('.carousel-viewport');


### PR DESCRIPTION
Summary
Playback speed control: New per-card speed button (1x / 1.25x / 1.5x / 1.75x / 2x) applied globally across all video slides, with pill-shaped styling and mobile-responsive sizing
Click side-peek to navigate: Clicking an inactive (grayed-out) carousel card now brings it into focus, with cursor: pointer to signal interactivity
Smarter control pulsation: Play button pulse deferred until the YouTube player is actually ready; mute button pulse deferred until the video is truly playing (not just buffering)
Responsive carousel spacing: Added breakpoints for narrow/wide screens so side-peek cards stay visible and properly spaced
Controls bar polish: Tightened bottom position and padding on hero controls
