### PR TITLE
Fix iOS video playback state desync on slide navigation

### DIFF
--- a/index.md
+++ b/index.md
@@ -439,11 +439,12 @@ function onYouTubeIframeAPIReady() {
           if (e.data === YT.PlayerState.ENDED) {
             players[idx].playVideo();
           }
-          // Trigger pulse when playback actually starts or pauses
+          // Sync UI when playback actually starts or pauses (handles iOS autoplay blocks)
           if (e.data === YT.PlayerState.PLAYING || e.data === YT.PlayerState.PAUSED) {
             slidePlaying[idx] = (e.data === YT.PlayerState.PLAYING);
-            if (idx === currentSlide && window._updatePulse) {
-              window._updatePulse(idx);
+            if (idx === currentSlide) {
+              if (window._syncControls) window._syncControls(idx);
+              if (window._updatePulse) window._updatePulse(idx);
             }
           }
         }
@@ -516,6 +517,7 @@ function onYouTubeIframeAPIReady() {
     // Pause previous video
     if (players[prevSlide] && players[prevSlide].pauseVideo) {
       try { players[prevSlide].pauseVideo(); } catch(e) {}
+      slidePlaying[prevSlide] = false;
     }
     // Pause connect audio when leaving a connect slide
     var prevEl = slides[prevSlide];
@@ -525,13 +527,28 @@ function onYouTubeIframeAPIReady() {
     }
 
     // Play new video (if it's a video slide)
-    if (players[currentSlide] && players[currentSlide].playVideo) {
+    var targetIdx = currentSlide;
+    if (players[targetIdx] && players[targetIdx].playVideo) {
       try {
-        if (globalMuted) { players[currentSlide].mute(); } else { players[currentSlide].unMute(); }
-        players[currentSlide].setPlaybackRate(globalSpeed);
-        players[currentSlide].playVideo();
-        slidePlaying[currentSlide] = true;
+        if (globalMuted) { players[targetIdx].mute(); } else { players[targetIdx].unMute(); }
+        players[targetIdx].setPlaybackRate(globalSpeed);
+        players[targetIdx].playVideo();
+        slidePlaying[targetIdx] = true;
       } catch(e) {}
+      // iOS may silently block playVideo(); verify actual state after a delay
+      setTimeout(function() {
+        if (targetIdx !== currentSlide) return; // user already navigated away
+        var p = players[targetIdx];
+        if (p && p.getPlayerState) {
+          var st = p.getPlayerState();
+          var actuallyPlaying = (st === YT.PlayerState.PLAYING);
+          if (slidePlaying[targetIdx] !== actuallyPlaying) {
+            slidePlaying[targetIdx] = actuallyPlaying;
+            syncControls(targetIdx);
+            updatePulse(targetIdx);
+          }
+        }
+      }, 300);
     }
     // Play connect audio when arriving at a connect slide
     var curEl = slides[currentSlide];
@@ -674,6 +691,7 @@ function onYouTubeIframeAPIReady() {
   // Expose for external use
   window._carouselGoTo = goTo;
   window._updatePulse = updatePulse;
+  window._syncControls = syncControls;
 })();
 
 // ===== Platform chooser popup =====


### PR DESCRIPTION
On iOS Chrome, playVideo() silently fails when swiping between videos due to autoplay restrictions, but the UI optimistically showed the "playing" state. This caused the play/pause button to indicate playing while the video was actually paused.

Three fixes:
- onStateChange now calls syncControls alongside updatePulse so the play/pause button CSS class reflects the actual player state
- goTo() adds a 300ms delayed verification that checks the real player state and corrects the UI if playVideo() was silently blocked
- Previous slide is immediately marked as not-playing when paused

This ensures pulsation correctly targets the play button (prompting the user to tap) rather than incorrectly pulsing the mute button.

https://claude.ai/code/session_01SrUfPKqcuNH6Mcgoa4WDMD