### PR TITLE
Reposition Follow button from floating pill to header nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,14 +43,14 @@
         </a>
       </div>
     </div>
-  </div>
-  <div class="nav-follow platform-trigger" id="nav-follow">
-    <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M18 11V6a2 2 0 00-4 0v1"/>
-      <path d="M14 10V4a2 2 0 00-4 0v6"/>
-      <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
-      <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
-    </svg>
-    <span class="nav-follow-text">Follow us!</span>
+    <div class="nav-follow platform-trigger" id="nav-follow">
+      <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 11V6a2 2 0 00-4 0v1"/>
+        <path d="M14 10V4a2 2 0 00-4 0v6"/>
+        <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
+        <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
+      </svg>
+      <span class="nav-follow-text">Follow us!</span>
+    </div>
   </div>
 </nav>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,4 +44,13 @@
       </div>
     </div>
   </div>
+  <div class="nav-follow platform-trigger" id="nav-follow">
+    <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 11V6a2 2 0 00-4 0v1"/>
+      <path d="M14 10V4a2 2 0 00-4 0v6"/>
+      <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
+      <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
+    </svg>
+    <span class="nav-follow-text">Follow us!</span>
+  </div>
 </nav>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -981,26 +981,23 @@ body {
 .platform-overlay.is-open .social-link:nth-child(3)::before { animation: socialPulse 8s ease-in-out 4.5s infinite; }
 .platform-overlay.is-open .social-link:nth-child(4)::before { animation: socialPulse 8s ease-in-out 6.5s infinite; }
 
-/* ===== FOLLOW NUDGE ===== */
-.follow-nudge {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  z-index: 999;
+/* ===== FOLLOW BUTTON (in header) ===== */
+.nav-follow {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   background: var(--clay);
   color: var(--flour);
   font-family: 'Kufam', sans-serif;
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 700;
-  padding: 15px 22px 14px 16px;
+  padding: 10px 18px 8px 14px;
   border-radius: 50px;
   cursor: pointer;
-  box-shadow: 0 6px 30px rgba(171, 79, 46, 0.5);
   border: 2px solid var(--wheat);
+  box-shadow: 0 4px 20px rgba(171, 79, 46, 0.4);
   animation: nudgeBounce 2s ease-in-out infinite 0.5s;
+  white-space: nowrap;
 }
 
 @keyframes nudgeBounce {
@@ -1008,18 +1005,18 @@ body {
   50% { transform: translateY(-6px) scale(1.03); }
 }
 
-.follow-nudge:hover {
+.nav-follow:hover {
   background: #c45a30;
   animation: none;
   transform: scale(1.05);
 }
 
-.follow-nudge-hand {
+.nav-follow-hand {
   color: var(--wheat);
   flex-shrink: 0;
 }
 
-.follow-nudge-text {
+.nav-follow-text {
   white-space: nowrap;
 }
 
@@ -1079,7 +1076,7 @@ body.mobile-device {
   height: auto;
   width: 100%;
   max-height: 100%;
-  margin-top: 32px;
+  margin-top: 70px; /* increased from 32px to make room for follow pill below header */
 }
 
 .mobile-device .card-header { padding: 8px 10px; }
@@ -1127,6 +1124,26 @@ body.mobile-device {
 .mobile-device .platform-heading { font-size: 22px; }
 .mobile-device .platform-row { gap: 8px; }
 
-/* Mobile: follow nudge */
-.mobile-device .follow-nudge { bottom: 16px; right: 16px; font-size: 13px; padding: 12px 18px 12px 14px; }
-.mobile-device .follow-nudge-hand { width: 22px; height: 22px; }
+/* Mobile: follow button — drops below header, centered above carousel */
+.mobile-device .nav-follow {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 6px;
+  font-size: 13px;
+  padding: 8px 16px 7px 12px;
+  box-shadow: 0 4px 16px rgba(171, 79, 46, 0.5);
+  animation: nudgeBounceMobile 2s ease-in-out infinite 0.5s;
+  z-index: 100;
+}
+.mobile-device .nav-follow:hover {
+  animation: none;
+  transform: translateX(-50%) scale(1.05);
+}
+.mobile-device .nav-follow-hand { width: 18px; height: 18px; }
+
+@keyframes nudgeBounceMobile {
+  0%, 100% { transform: translateX(-50%) translateY(0) scale(1); }
+  50% { transform: translateX(-50%) translateY(-4px) scale(1.03); }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1135,7 +1135,7 @@ body.mobile-device {
   padding: 8px 16px 7px 12px;
   box-shadow: 0 4px 16px rgba(171, 79, 46, 0.5);
   animation: nudgeBounceMobile 2s ease-in-out infinite 0.5s;
-  z-index: 100;
+  z-index: 50; /* below pill-dropdown (z-index: 100) so dropdowns aren't hidden */
 }
 .mobile-device .nav-follow:hover {
   animation: none;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1061,6 +1061,7 @@ body.mobile-device {
 .mobile-device .pill-dropdown { width: 105px; padding: 8px 0 6px; }
 .mobile-device .pill-dd-link { font-size: 11px; padding: 5px 10px; }
 .mobile-device .pill-dd-link img { width: 16px; height: 16px; }
+.mobile-device .nav-pill-wrap:last-child .pill-dropdown { left: 20%; }
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1130,7 +1130,7 @@ body.mobile-device {
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 6px;
+  margin-top: 16px;
   font-size: 13px;
   padding: 8px 16px 7px 12px;
   box-shadow: 0 4px 16px rgba(171, 79, 46, 0.5);

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1064,7 +1064,7 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {
-  height: 86vh;
+  height: 90vh;
 }
 .mobile-device .carousel-viewport {
   padding: 24px 8px 26px;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1067,7 +1067,7 @@ body.mobile-device {
   height: 90vh;
 }
 .mobile-device .carousel-viewport {
-  padding: 24px 8px 26px;
+  padding: 0px 8px 26px;
 }
 .mobile-device .carousel-slide {
   padding: 0 16px;

--- a/index.md
+++ b/index.md
@@ -373,17 +373,6 @@ title: Home
   </div>
 </div>
 
-<!-- ====== FOLLOW NUDGE (appears after 5s) ====== -->
-<div class="follow-nudge" id="follow-nudge">
-  <svg class="follow-nudge-hand" viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M18 11V6a2 2 0 00-4 0v1"/>
-    <path d="M14 10V4a2 2 0 00-4 0v6"/>
-    <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
-    <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
-  </svg>
-  <span class="follow-nudge-text">Follow us!</span>
-</div>
-
 <!-- YouTube IFrame API -->
 <script>
 var tag = document.createElement('script');
@@ -703,12 +692,4 @@ function onYouTubeIframeAPIReady() {
   window._openPlatformPopup = openPopup;
 })();
 
-// ===== Follow nudge =====
-(function() {
-  var nudge = document.getElementById('follow-nudge');
-  if (!nudge) return;
-  nudge.addEventListener('click', function() {
-    if (window._openPlatformPopup) window._openPlatformPopup();
-  });
-})();
 </script>


### PR DESCRIPTION
## Summary
- **Desktop**: Follow pill moved into the header nav alongside content pills (Health Bites, Roti 101, Fun), styled with clay background + wheat border to stand out as a CTA, with bounce animation preserved
- **Mobile**: Follow pill drops below the fixed header as a centered strip above the video carousel, with dedicated bounce animation that combines centering and vertical bounce
- Removed the old fixed-position bottom-right floating follow-nudge
- Fixed z-index layering so nav pill dropdowns render above the Follow pill on mobile
- Shifted Fun pill dropdown left on mobile to prevent right-edge clipping

https://claude.ai/code/session_01NRBnPAyfkGAG82uFnire8N
