### PR TITLE
Auto-advance carousel to next slide when video finishes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# RotiTales — Brand & Style Guide
+
+## Color Palette (CSS custom properties only)
+
+Never hardcode hex/rgb values in stylesheets. Always use the CSS custom properties defined in `:root` of `assets/css/style.scss`:
+
+| Token              | Value     | Usage                              |
+|--------------------|-----------|------------------------------------|
+| `--flour`          | #FFF5E8   | Primary background                 |
+| `--flour-light`    | #FFFDFA   | Lighter background variant         |
+| `--flour-30`       | #FFF5E84D | 30% opacity flour                  |
+| `--clay`           | #AB4F2E   | Primary accent / body text color   |
+| `--clay-light`     | #CF9880   | Lighter clay                       |
+| `--clay-30`        | #AB4F2E4D | 30% opacity clay                   |
+| `--wheat`          | #F6BA59   | Secondary accent / highlights      |
+| `--wheat-light`    | #FDE1B9   | Lighter wheat                      |
+| `--wheat-30`       | #F5B8594D | 30% opacity wheat                  |
+| `--warmth`         | #4D000A   | Deep red / headings                |
+| `--warmth-dark`    | #240203   | Darkest brand shade / page bg      |
+| `--warmth-30`      | #4D000A4D | 30% opacity warmth                 |
+| `--abundance`      | #2E6121   | Green accent                       |
+| `--abundance-light`| #98B690   | Lighter green                      |
+| `--abundance-30`   | #2E61214D | 30% opacity green                  |
+
+If you need a new shade, add a CSS custom property to `:root` — do not inline a hex value.
+
+## Typography
+
+- **Font**: `'Kufam', sans-serif` — the only font used across the site.
+- There is no `--font-display` or other font variable. Always write `font-family: 'Kufam', sans-serif;` directly.
+
+## Key Rules
+
+1. **No hardcoded hex/rgb colors** outside `:root`. Use `var(--token)` everywhere.
+2. **Stick to the brand palette.** Do not invent colors. If a new shade is needed, add it to `:root` with a descriptive name following the existing pattern (base / light / 30).
+3. **z-index layers** (from low to high): carousel content (6) → tagline (7) → controls (10) → Follow button mobile (50) → nav & dropdowns (100) → cookie overlay (9999) → platform popup (10000).
+4. **Mobile overrides** use the `.mobile-device` class (set via JS UA sniff on `<body>`), not media queries.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,14 +43,16 @@
         </a>
       </div>
     </div>
-    <div class="nav-follow platform-trigger" id="nav-follow">
-      <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M18 11V6a2 2 0 00-4 0v1"/>
-        <path d="M14 10V4a2 2 0 00-4 0v6"/>
-        <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
-        <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
-      </svg>
-      <span class="nav-follow-text">Follow us!</span>
-    </div>
   </div>
 </nav>
+
+<!-- Follow CTA — visually overlaps the nav area but is not a nav element -->
+<div class="nav-follow platform-trigger" id="nav-follow">
+  <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M18 11V6a2 2 0 00-4 0v1"/>
+    <path d="M14 10V4a2 2 0 00-4 0v6"/>
+    <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
+    <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
+  </svg>
+  <span class="nav-follow-text">Follow us!</span>
+</div>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -35,7 +35,7 @@ body {
 /* ===== CAROUSEL TAGLINE ===== */
 .carousel-tagline {
   position: absolute;
-  top: 80px;                          /* below fixed nav (~76px) */
+  top: 84px;                          /* below fixed nav (~76px) */
   left: 50%;
   transform: translateX(-50%);
   z-index: 7;                         /* above carousel (6) but below nav (100) */
@@ -53,11 +53,14 @@ body {
   white-space: nowrap;
 }
 .mobile-device .carousel-tagline {
-  top: 100px;                         /* extra room for Follow button that drops below nav */
-  font-size: .82rem;
+  top: 58px;                          /* same row as Follow button */
+  left: 12px;
+  transform: none;
+  text-align: left;
+  font-size: .78rem;
   padding: .35rem .9rem;
   white-space: normal;
-  max-width: 85vw;
+  max-width: 55vw;                    /* leave room for Follow button on the right */
 }
 
 /* ===== FULL-SCREEN CAROUSEL ===== */
@@ -76,7 +79,7 @@ body {
 .carousel-viewport {
   flex: 1;
   overflow: hidden;
-  padding: 110px 32px 80px;
+  padding: 130px 32px 80px;
   box-sizing: border-box;
   display: flex;
   align-items: center;
@@ -1009,8 +1012,12 @@ body {
 .platform-overlay.is-open .social-link:nth-child(3)::before { animation: socialPulse 8s ease-in-out 4.5s infinite; }
 .platform-overlay.is-open .social-link:nth-child(4)::before { animation: socialPulse 8s ease-in-out 6.5s infinite; }
 
-/* ===== FOLLOW BUTTON (in header) ===== */
+/* ===== FOLLOW BUTTON (floats over nav, not inside it) ===== */
 .nav-follow {
+  position: fixed;
+  top: 10px;
+  right: 32px;
+  z-index: 100;                       /* same layer as nav */
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1105,7 +1112,7 @@ body.mobile-device {
   height: auto;
   width: 100%;
   max-height: 100%;
-  margin-top: 70px; /* increased from 32px to make room for follow pill below header */
+  margin-top: 50px; /* tagline + follow now share one row below nav */
 }
 
 .mobile-device .card-header { padding: 8px 10px; }
@@ -1153,26 +1160,25 @@ body.mobile-device {
 .mobile-device .platform-heading { font-size: 22px; }
 .mobile-device .platform-row { gap: 8px; }
 
-/* Mobile: follow button — drops below header, centered above carousel */
+/* Mobile: follow button — fixed, right side, below nav, shares row with tagline */
 .mobile-device .nav-follow {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-top: 16px;
+  top: 56px;
+  right: 12px;
+  left: auto;
+  transform: none;
   font-size: 13px;
   padding: 8px 16px 7px 12px;
   box-shadow: 0 4px 16px rgba(171, 79, 46, 0.5);
   animation: nudgeBounceMobile 2s ease-in-out infinite 0.5s;
-  z-index: 50; /* below pill-dropdown (z-index: 100) so dropdowns aren't hidden */
+  z-index: 50;
 }
 .mobile-device .nav-follow:hover {
   animation: none;
-  transform: translateX(-50%) scale(1.05);
+  transform: scale(1.05);
 }
 .mobile-device .nav-follow-hand { width: 18px; height: 18px; }
 
 @keyframes nudgeBounceMobile {
-  0%, 100% { transform: translateX(-50%) translateY(0) scale(1); }
-  50% { transform: translateX(-50%) translateY(-4px) scale(1.03); }
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-4px) scale(1.03); }
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -41,7 +41,7 @@ body {
   z-index: 7;                         /* above carousel (6) but below nav (100) */
   text-align: center;
   font-family: 'Kufam', sans-serif;
-  font-size: 1.1rem;
+  font-size: 1rem;
   color: var(--warmth);
   margin: 0;
   padding: .4rem 1.2rem;
@@ -53,14 +53,14 @@ body {
   white-space: nowrap;
 }
 .mobile-device .carousel-tagline {
-  top: 58px;                          /* same row as Follow button */
+  top: 54px;
   left: 12px;
   transform: none;
   text-align: left;
   font-size: .78rem;
-  padding: .35rem .9rem;
+  padding: 0.2rem;
   white-space: normal;
-  max-width: 55vw;                    /* leave room for Follow button on the right */
+  max-width: 50vw;
 }
 
 /* ===== FULL-SCREEN CAROUSEL ===== */
@@ -1015,7 +1015,7 @@ body {
 /* ===== FOLLOW BUTTON (floats over nav, not inside it) ===== */
 .nav-follow {
   position: fixed;
-  top: 10px;
+  top: 92px;
   right: 32px;
   z-index: 100;                       /* same layer as nav */
   display: flex;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -34,14 +34,30 @@ body {
 
 /* ===== CAROUSEL TAGLINE ===== */
 .carousel-tagline {
+  position: absolute;
+  top: 80px;                          /* below fixed nav (~76px) */
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 7;                         /* above carousel (6) but below nav (100) */
   text-align: center;
   font-family: var(--font-display);
-  font-size: 1.15rem;
+  font-size: 1.1rem;
   color: var(--crust);
   margin: 0;
-  padding: .6rem 1rem;
-  background: var(--flour);
+  padding: .4rem 1.2rem;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border-radius: 20px;
   letter-spacing: .02em;
+  white-space: nowrap;
+}
+.mobile-device .carousel-tagline {
+  top: 100px;                         /* extra room for Follow button that drops below nav */
+  font-size: .82rem;
+  padding: .35rem .9rem;
+  white-space: normal;
+  max-width: 85vw;
 }
 
 /* ===== FULL-SCREEN CAROUSEL ===== */

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -40,12 +40,12 @@ body {
   transform: translateX(-50%);
   z-index: 7;                         /* above carousel (6) but below nav (100) */
   text-align: center;
-  font-family: var(--font-display);
+  font-family: 'Kufam', sans-serif;
   font-size: 1.1rem;
-  color: var(--crust);
+  color: var(--warmth);
   margin: 0;
   padding: .4rem 1.2rem;
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--flour-30);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   border-radius: 20px;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1034,7 +1034,7 @@ body {
 }
 
 .nav-follow:hover {
-  background: #c45a30;
+  background: var(--clay);
   animation: none;
   transform: scale(1.05);
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -32,6 +32,18 @@ body {
   margin: 0;
 }
 
+/* ===== CAROUSEL TAGLINE ===== */
+.carousel-tagline {
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  color: var(--crust);
+  margin: 0;
+  padding: .6rem 1rem;
+  background: var(--flour);
+  letter-spacing: .02em;
+}
+
 /* ===== FULL-SCREEN CAROUSEL ===== */
 .hero-carousel {
   position: relative;

--- a/index.md
+++ b/index.md
@@ -403,8 +403,7 @@ function onYouTubeIframeAPIReady() {
         controls: 0,
         showinfo: 0,
         rel: 0,
-        loop: 1,
-        playlist: videoId,
+        loop: 0,
         modestbranding: 1,
         iv_load_policy: 3,
         disablekb: 1,
@@ -426,7 +425,10 @@ function onYouTubeIframeAPIReady() {
         },
         onStateChange: function(e) {
           if (e.data === YT.PlayerState.ENDED) {
-            players[idx].playVideo();
+            // Auto-advance to next slide when video finishes
+            if (idx === currentSlide && window._carouselGoTo) {
+              window._carouselGoTo(currentSlide + 1);
+            }
           }
           // Trigger pulse when playback actually starts or pauses
           if (e.data === YT.PlayerState.PLAYING || e.data === YT.PlayerState.PAUSED) {

--- a/index.md
+++ b/index.md
@@ -3,10 +3,10 @@ layout: home
 title: Home
 ---
 
-<p class="carousel-tagline">Taste a little sample of our content through these reels</p>
-
 <!-- ====== FULL-SCREEN VIDEO CAROUSEL ====== -->
 <div class="hero-carousel">
+
+  <p class="carousel-tagline">Taste a little sample of our content through these reels</p>
 
   <!-- Carousel viewport -->
   <div class="carousel-viewport">

--- a/index.md
+++ b/index.md
@@ -3,6 +3,8 @@ layout: home
 title: Home
 ---
 
+<p class="carousel-tagline">Taste a little sample of our content through these reels</p>
+
 <!-- ====== FULL-SCREEN VIDEO CAROUSEL ====== -->
 <div class="hero-carousel">
 


### PR DESCRIPTION
Instead of looping the current video when it ends, the slider now automatically advances to the next slide. Disabled YouTube's built-in loop/playlist params so the ENDED event fires properly, and replaced the replay call with a goTo(currentSlide + 1) via the exposed _carouselGoTo helper.

https://claude.ai/code/session_0143nC4NT996qV7tspHRzqhw