### PR TITLE
Reposition Follow button to header nav + add analytics & UTM tracking

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="site-footer">
     <div class="footer-inner">
-        <span class="footer-copy">© <script>document.write(new Date().getFullYear())</script> <a href="https://poshan.us" class="footer-link">Poshan, Inc.</a> All rights reserved.</span>
+        <span class="footer-copy">© <script>document.write(new Date().getFullYear())</script> <a href="https://poshan.us?utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content=footer" class="footer-link" rel="noopener noreferrer" data-platform="poshan" data-source="footer">Poshan, Inc.</a> All rights reserved.</span>
     </div>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,11 +7,11 @@
     <div class="nav-pill-wrap">
       <span class="nav-pill">Health Bites</span>
       <div class="pill-dropdown">
-        <a href="https://www.instagram.com/stories/highlights/18087218473855282/" class="pill-dd-link">
+        <a href="https://www.instagram.com/stories/highlights/18087218473855282/?utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content=nav-healthbites" class="pill-dd-link" rel="noopener noreferrer" data-platform="instagram" data-source="nav-healthbites">
           <img src="/assets/icons/instagram-flour.svg" alt="Instagram" />
           <span>Instagram</span>
         </a>
-        <a href="https://www.youtube.com/watch?v=5VvCXdIaX_k&list=PLca7YZGvJBnX8Q_pfbBsePRChDufQQVE2&index=2" class="pill-dd-link">
+        <a href="https://www.youtube.com/watch?v=5VvCXdIaX_k&list=PLca7YZGvJBnX8Q_pfbBsePRChDufQQVE2&index=2&utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content=nav-healthbites" class="pill-dd-link" rel="noopener noreferrer" data-platform="youtube" data-source="nav-healthbites">
           <img src="/assets/icons/youtube-flour.svg" alt="YouTube" />
           <span>YouTube</span>
         </a>
@@ -20,11 +20,11 @@
     <div class="nav-pill-wrap">
       <span class="nav-pill">Roti 101</span>
       <div class="pill-dropdown">
-        <a href="https://www.instagram.com/stories/highlights/18098705317909029/" class="pill-dd-link">
+        <a href="https://www.instagram.com/stories/highlights/18098705317909029/?utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content=nav-roti101" class="pill-dd-link" rel="noopener noreferrer" data-platform="instagram" data-source="nav-roti101">
           <img src="/assets/icons/instagram-flour.svg" alt="Instagram" />
           <span>Instagram</span>
         </a>
-        <a href="https://www.youtube.com/watch?v=45Cvzh2U818&list=PLca7YZGvJBnVSU9YJHQxNBf3IhjaUNjFm" class="pill-dd-link">
+        <a href="https://www.youtube.com/watch?v=45Cvzh2U818&list=PLca7YZGvJBnVSU9YJHQxNBf3IhjaUNjFm&utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content=nav-roti101" class="pill-dd-link" rel="noopener noreferrer" data-platform="youtube" data-source="nav-roti101">
           <img src="/assets/icons/youtube-flour.svg" alt="YouTube" />
           <span>YouTube</span>
         </a>
@@ -33,11 +33,11 @@
     <div class="nav-pill-wrap">
       <span class="nav-pill">Fun &infin;</span>
       <div class="pill-dropdown">
-        <a href="https://www.instagram.com/stories/highlights/18072866213573793/" class="pill-dd-link">
+        <a href="https://www.instagram.com/stories/highlights/18072866213573793/?utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content=nav-fun" class="pill-dd-link" rel="noopener noreferrer" data-platform="instagram" data-source="nav-fun">
           <img src="/assets/icons/instagram-flour.svg" alt="Instagram" />
           <span>Instagram</span>
         </a>
-        <a href="https://www.youtube.com/watch?v=glaOtsCsEi4&list=PLca7YZGvJBnW5nJvhTloNmb1cnmG42FVR&index=1" class="pill-dd-link">
+        <a href="https://www.youtube.com/watch?v=glaOtsCsEi4&list=PLca7YZGvJBnW5nJvhTloNmb1cnmG42FVR&index=1&utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content=nav-fun" class="pill-dd-link" rel="noopener noreferrer" data-platform="youtube" data-source="nav-fun">
           <img src="/assets/icons/youtube-flour.svg" alt="YouTube" />
           <span>YouTube</span>
         </a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,15 +43,6 @@
         </a>
       </div>
     </div>
-    <div class="nav-follow platform-trigger" id="nav-follow">
-      <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M18 11V6a2 2 0 00-4 0v1"/>
-        <path d="M14 10V4a2 2 0 00-4 0v6"/>
-        <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
-        <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
-      </svg>
-      <span class="nav-follow-text">Follow us!</span>
-    </div>
   </div>
 </nav>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,14 +43,14 @@
         </a>
       </div>
     </div>
-  </div>
-  <div class="nav-follow platform-trigger" id="nav-follow">
-    <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M18 11V6a2 2 0 00-4 0v1"/>
-      <path d="M14 10V4a2 2 0 00-4 0v6"/>
-      <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
-      <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
-    </svg>
-    <span class="nav-follow-text">Follow us!</span>
+    <div class="nav-follow platform-trigger" id="nav-follow">
+      <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 11V6a2 2 0 00-4 0v1"/>
+        <path d="M14 10V4a2 2 0 00-4 0v6"/>
+        <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
+        <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
+      </svg>
+      <span class="nav-follow-text">Follow us!</span>
+    </div>
   </div>
 </nav>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,4 +44,13 @@
       </div>
     </div>
   </div>
+  <div class="nav-follow platform-trigger" id="nav-follow">
+    <svg class="nav-follow-hand" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 11V6a2 2 0 00-4 0v1"/>
+      <path d="M14 10V4a2 2 0 00-4 0v6"/>
+      <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
+      <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
+    </svg>
+    <span class="nav-follow-text">Follow us!</span>
+  </div>
 </nav>

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -1,5 +1,5 @@
 {% for social in site.data.socials %}
-<a href="{{ social.url }}" class="{{ include.class }}">
+<a href="{{ social.url }}?utm_source=rotitales&utm_medium=website&utm_campaign=follow&utm_content={{ include.source }}" class="{{ include.class }}" rel="noopener noreferrer" data-platform="{{ social.name | downcase }}" data-source="{{ include.source }}">
   <img src="/assets/icons/{{ social.icon }}" alt="{{ social.name }}" />
   <span>{{ social.name }}</span>
 </a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -150,14 +150,11 @@
         s.src = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+web-analytics.min.js';
         s.setAttribute('data-client-key', STATSIG_KEY);
         s.onload = function() {
-            var attempts = 0;
-            (function tryFlush() {
-                if (window.__STATSIG_CLIENT__) {
-                    if (window.__rtAnalytics) window.__rtAnalytics.flushQueue();
-                } else if (attempts++ < 30) {
-                    setTimeout(tryFlush, 100);
-                }
-            })();
+            // v3 SDK exposes the auto-initialized singleton via window.Statsig.instance()
+            try { window.__STATSIG_CLIENT__ = window.Statsig.instance(); } catch(e) {}
+            if (window.__STATSIG_CLIENT__ && window.__rtAnalytics) {
+                window.__rtAnalytics.flushQueue();
+            }
         };
         document.head.appendChild(s);
     }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,6 +89,22 @@
     });
   });
 
+  // nav_dropdown_opened — fires once per hover into a pill wrapper
+  var lastDropdown = '';
+  document.addEventListener('mouseover', function(e) {
+    var wrap = e.target.closest('.nav-pill-wrap');
+    if (!wrap) { lastDropdown = ''; return; }
+    var pill = wrap.querySelector('.nav-pill');
+    if (!pill) return;
+    var name = pill.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-$/, '');
+    if (name === lastDropdown) return;
+    lastDropdown = name;
+    logEvent('nav_dropdown_opened', {
+      dropdown: name,
+      time_on_site_ms: String(timeSinceLoad())
+    });
+  });
+
   // page_exited via visibilitychange (reliable on mobile + desktop)
   document.addEventListener('visibilitychange', function() {
     if (document.visibilityState === 'hidden') {
@@ -127,13 +143,21 @@
 
 <script>
 (function() {
-    var STATSIG_SRC = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+web-analytics.min.js?apikey=client-XBaeJ6hvk0nI45w5ERTiznvlzNfA2QcYdXAC6VFg29e';
+    var STATSIG_KEY = 'client-XBaeJ6hvk0nI45w5ERTiznvlzNfA2QcYdXAC6VFg29e';
 
     function loadStatsig() {
         var s = document.createElement('script');
-        s.src = STATSIG_SRC;
+        s.src = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+web-analytics.min.js';
+        s.setAttribute('data-client-key', STATSIG_KEY);
         s.onload = function() {
-            if (window.__rtAnalytics) window.__rtAnalytics.flushQueue();
+            var attempts = 0;
+            (function tryFlush() {
+                if (window.__STATSIG_CLIENT__) {
+                    if (window.__rtAnalytics) window.__rtAnalytics.flushQueue();
+                } else if (attempts++ < 30) {
+                    setTimeout(tryFlush, 100);
+                }
+            })();
         };
         document.head.appendChild(s);
     }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,80 @@
 })(navigator.userAgent||navigator.vendor||window.opera,'');
 </script>
 
+<!-- Analytics layer — queues events until Statsig is ready -->
+<script>
+(function() {
+  var pageLoadedAt = Date.now();
+  var popupOpenedAt = 0;
+  var linkClickedInSession = false;
+  var eventQueue = [];
+  var statsigReady = false;
+
+  function logEvent(name, metadata) {
+    metadata = metadata || {};
+    if (statsigReady && window.__STATSIG_CLIENT__) {
+      window.__STATSIG_CLIENT__.logEvent(name, null, metadata);
+    } else {
+      eventQueue.push({ name: name, metadata: metadata });
+    }
+  }
+
+  function flushQueue() {
+    statsigReady = true;
+    var client = window.__STATSIG_CLIENT__;
+    if (client) {
+      eventQueue.forEach(function(evt) {
+        client.logEvent(evt.name, null, evt.metadata);
+      });
+    }
+    eventQueue = [];
+  }
+
+  function timeSinceLoad() {
+    return Date.now() - pageLoadedAt;
+  }
+
+  window.__rtAnalytics = {
+    logEvent: logEvent,
+    flushQueue: flushQueue,
+    timeSinceLoad: timeSinceLoad,
+    pageLoadedAt: pageLoadedAt,
+    popupOpenedAt: function(t) { if (t !== undefined) popupOpenedAt = t; return popupOpenedAt; },
+    linkClicked: function() { linkClickedInSession = true; },
+    wasLinkClicked: function() { return linkClickedInSession; }
+  };
+
+  // page_loaded
+  logEvent('page_loaded', { timestamp: new Date().toISOString() });
+
+  // Delegated link_clicked for any <a data-source>
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[data-source]');
+    if (!link) return;
+    linkClickedInSession = true;
+    logEvent('link_clicked', {
+      platform: link.getAttribute('data-platform') || '',
+      source: link.getAttribute('data-source') || '',
+      url: link.href || '',
+      time_on_site_ms: String(timeSinceLoad())
+    });
+  });
+
+  // page_exited via visibilitychange (reliable on mobile + desktop)
+  document.addEventListener('visibilitychange', function() {
+    if (document.visibilityState === 'hidden') {
+      logEvent('page_exited', {
+        time_on_site_ms: String(timeSinceLoad()),
+        link_clicked_in_session: String(linkClickedInSession)
+      });
+      if (window.__STATSIG_CLIENT__ && window.__STATSIG_CLIENT__.flush) {
+        window.__STATSIG_CLIENT__.flush();
+      }
+    }
+  });
+})();
+</script>
+
     {% include header.html %}
 
     <main class="site-main">
@@ -53,11 +127,14 @@
 
 <script>
 (function() {
-    var STATSIG_SRC = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+session-replay+web-analytics.min.js?apikey=client-XBaeJ6hvk0nI45w5ERTiznvlzNfA2QcYdXAC6VFg29e';
+    var STATSIG_SRC = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+web-analytics.min.js?apikey=client-XBaeJ6hvk0nI45w5ERTiznvlzNfA2QcYdXAC6VFg29e';
 
     function loadStatsig() {
         var s = document.createElement('script');
         s.src = STATSIG_SRC;
+        s.onload = function() {
+            if (window.__rtAnalytics) window.__rtAnalytics.flushQueue();
+        };
         document.head.appendChild(s);
     }
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -147,11 +147,14 @@
 
     function loadStatsig() {
         var s = document.createElement('script');
-        s.src = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+web-analytics.min.js';
-        s.setAttribute('data-client-key', STATSIG_KEY);
+        s.src = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client.min.js';
         s.onload = function() {
-            // v3 SDK exposes the auto-initialized singleton via window.Statsig.instance()
-            try { window.__STATSIG_CLIENT__ = window.Statsig.instance(); } catch(e) {}
+            try {
+                var SC = window.Statsig.StatsigClient;
+                var client = new SC(STATSIG_KEY, {});
+                client.initializeAsync();
+                window.__STATSIG_CLIENT__ = client;
+            } catch(e) {}
             if (window.__STATSIG_CLIENT__ && window.__rtAnalytics) {
                 window.__rtAnalytics.flushQueue();
             }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -981,26 +981,23 @@ body {
 .platform-overlay.is-open .social-link:nth-child(3)::before { animation: socialPulse 8s ease-in-out 4.5s infinite; }
 .platform-overlay.is-open .social-link:nth-child(4)::before { animation: socialPulse 8s ease-in-out 6.5s infinite; }
 
-/* ===== FOLLOW NUDGE ===== */
-.follow-nudge {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  z-index: 999;
+/* ===== FOLLOW BUTTON (in header) ===== */
+.nav-follow {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   background: var(--clay);
   color: var(--flour);
   font-family: 'Kufam', sans-serif;
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 700;
-  padding: 15px 22px 14px 16px;
+  padding: 10px 18px 8px 14px;
   border-radius: 50px;
   cursor: pointer;
-  box-shadow: 0 6px 30px rgba(171, 79, 46, 0.5);
   border: 2px solid var(--wheat);
+  box-shadow: 0 4px 20px rgba(171, 79, 46, 0.4);
   animation: nudgeBounce 2s ease-in-out infinite 0.5s;
+  white-space: nowrap;
 }
 
 @keyframes nudgeBounce {
@@ -1008,18 +1005,18 @@ body {
   50% { transform: translateY(-6px) scale(1.03); }
 }
 
-.follow-nudge:hover {
+.nav-follow:hover {
   background: #c45a30;
   animation: none;
   transform: scale(1.05);
 }
 
-.follow-nudge-hand {
+.nav-follow-hand {
   color: var(--wheat);
   flex-shrink: 0;
 }
 
-.follow-nudge-text {
+.nav-follow-text {
   white-space: nowrap;
 }
 
@@ -1079,7 +1076,7 @@ body.mobile-device {
   height: auto;
   width: 100%;
   max-height: 100%;
-  margin-top: 32px;
+  margin-top: 70px; /* increased from 32px to make room for follow pill below header */
 }
 
 .mobile-device .card-header { padding: 8px 10px; }
@@ -1127,6 +1124,26 @@ body.mobile-device {
 .mobile-device .platform-heading { font-size: 22px; }
 .mobile-device .platform-row { gap: 8px; }
 
-/* Mobile: follow nudge */
-.mobile-device .follow-nudge { bottom: 16px; right: 16px; font-size: 13px; padding: 12px 18px 12px 14px; }
-.mobile-device .follow-nudge-hand { width: 22px; height: 22px; }
+/* Mobile: follow button — drops below header, centered above carousel */
+.mobile-device .nav-follow {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 6px;
+  font-size: 13px;
+  padding: 8px 16px 7px 12px;
+  box-shadow: 0 4px 16px rgba(171, 79, 46, 0.5);
+  animation: nudgeBounceMobile 2s ease-in-out infinite 0.5s;
+  z-index: 100;
+}
+.mobile-device .nav-follow:hover {
+  animation: none;
+  transform: translateX(-50%) scale(1.05);
+}
+.mobile-device .nav-follow-hand { width: 18px; height: 18px; }
+
+@keyframes nudgeBounceMobile {
+  0%, 100% { transform: translateX(-50%) translateY(0) scale(1); }
+  50% { transform: translateX(-50%) translateY(-4px) scale(1.03); }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1135,7 +1135,7 @@ body.mobile-device {
   padding: 8px 16px 7px 12px;
   box-shadow: 0 4px 16px rgba(171, 79, 46, 0.5);
   animation: nudgeBounceMobile 2s ease-in-out infinite 0.5s;
-  z-index: 100;
+  z-index: 50; /* below pill-dropdown (z-index: 100) so dropdowns aren't hidden */
 }
 .mobile-device .nav-follow:hover {
   animation: none;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1017,7 +1017,7 @@ body {
   position: fixed;
   top: 92px;
   right: 32px;
-  z-index: 100;                       /* same layer as nav */
+  z-index: 99;                        /* below nav (100) so pill dropdowns aren't hidden */
   display: flex;
   align-items: center;
   gap: 8px;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1061,6 +1061,7 @@ body.mobile-device {
 .mobile-device .pill-dropdown { width: 105px; padding: 8px 0 6px; }
 .mobile-device .pill-dd-link { font-size: 11px; padding: 5px 10px; }
 .mobile-device .pill-dd-link img { width: 16px; height: 16px; }
+.mobile-device .nav-pill-wrap:last-child .pill-dropdown { left: 20%; }
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1130,7 +1130,7 @@ body.mobile-device {
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 6px;
+  margin-top: 16px;
   font-size: 13px;
   padding: 8px 16px 7px 12px;
   box-shadow: 0 4px 16px rgba(171, 79, 46, 0.5);

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1064,7 +1064,7 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {
-  height: 86vh;
+  height: 90vh;
 }
 .mobile-device .carousel-viewport {
   padding: 24px 8px 26px;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1067,7 +1067,7 @@ body.mobile-device {
   height: 90vh;
 }
 .mobile-device .carousel-viewport {
-  padding: 24px 8px 26px;
+  padding: 0px 8px 26px;
 }
 .mobile-device .carousel-slide {
   padding: 0 16px;

--- a/index.md
+++ b/index.md
@@ -373,17 +373,6 @@ title: Home
   </div>
 </div>
 
-<!-- ====== FOLLOW NUDGE (appears after 5s) ====== -->
-<div class="follow-nudge" id="follow-nudge">
-  <svg class="follow-nudge-hand" viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M18 11V6a2 2 0 00-4 0v1"/>
-    <path d="M14 10V4a2 2 0 00-4 0v6"/>
-    <path d="M10 10.5V6a2 2 0 00-4 0v8"/>
-    <path d="M18 11a2 2 0 014 0v3a8 8 0 01-8 8h-2c-2.5 0-4.5-1-6.2-2.8L3 16.4a2 2 0 013-2.6l.6.6"/>
-  </svg>
-  <span class="follow-nudge-text">Follow us!</span>
-</div>
-
 <!-- YouTube IFrame API -->
 <script>
 var tag = document.createElement('script');
@@ -703,12 +692,4 @@ function onYouTubeIframeAPIReady() {
   window._openPlatformPopup = openPopup;
 })();
 
-// ===== Follow nudge =====
-(function() {
-  var nudge = document.getElementById('follow-nudge');
-  if (!nudge) return;
-  nudge.addEventListener('click', function() {
-    if (window._openPlatformPopup) window._openPlatformPopup();
-  });
-})();
 </script>


### PR DESCRIPTION
## Summary
- Moved Follow button from floating bottom-right corner into the header nav bar for better UX
- Fixed mobile nav issues: dropdowns hidden behind Follow pill, Fun pill clipping off-screen
- Adjusted mobile carousel height (86vh → 90vh) and removed extra top padding
- Added analytics event layer (page_loaded, link_clicked, follow_popup_opened/closed, page_exited) queued until Statsig loads
- Added UTM attribution on all outbound links with source-specific utm_content (popup, nav-healthbites, nav-roti101, nav-fun, carousel-early, carousel-late, footer)
- Added rel="noopener noreferrer" on all external links
- Dropped session-replay from Statsig bundle
