### PR TITLE
Reposition follow button & fix mobile carousel layout

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1098,8 +1098,11 @@ body.mobile-device {
 .mobile-device .nav-pill-wrap:last-child .pill-dropdown { left: 20%; }
 
 /* Mobile: carousel */
+.mobile-device .hero-carousel {
+  max-height: calc((100vw - 32px) * 16 / 9 + 170px);
+}
 .mobile-device .carousel-viewport {
-  padding: max(80px, 150px - 10vh) 16px 26px;
+  padding: 90px 16px 26px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1099,7 +1099,7 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .carousel-viewport {
-  padding: 90px 16px 26px;
+  padding: 100px 16px 26px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -79,7 +79,7 @@ body {
 .carousel-viewport {
   flex: 1;
   overflow: hidden;
-  padding: 130px 32px 80px;
+  padding: 130px 42px 80px;
   box-sizing: border-box;
   display: flex;
   align-items: center;
@@ -99,7 +99,6 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 10px;
   box-sizing: border-box;
 }
 
@@ -1099,20 +1098,13 @@ body.mobile-device {
 .mobile-device .nav-pill-wrap:last-child .pill-dropdown { left: 20%; }
 
 /* Mobile: carousel */
-.mobile-device .hero-carousel {
-  height: 90vh;
-}
 .mobile-device .carousel-viewport {
-  padding: 0px 8px 26px;
-}
-.mobile-device .carousel-slide {
-  padding: 0 16px;
+  padding: 0px 16px 26px;
 }
 .mobile-device .slide-card {
   height: auto;
   width: 100%;
   max-height: 100%;
-  margin-top: 50px; /* tagline + follow now share one row below nav */
 }
 
 .mobile-device .card-header { padding: 8px 10px; }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1099,10 +1099,10 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {
-  max-height: calc((100vw - 32px) * 16 / 9 + 170px);
+  max-height: calc((100vw - 48px) * 16 / 9 + 120px);
 }
 .mobile-device .carousel-viewport {
-  padding: 90px 16px 26px;
+  padding: 56px 24px 12px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1099,7 +1099,7 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .carousel-viewport {
-  padding: 0px 16px 26px;
+  padding: 90px 16px 26px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1099,7 +1099,7 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .carousel-viewport {
-  padding: 90px 16px 26px;
+  padding: max(80px, 150px - 10vh) 16px 26px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1099,7 +1099,7 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .carousel-viewport {
-  padding: 100px 16px 26px;
+  padding: 90px 16px 26px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: Home
 <!-- ====== FULL-SCREEN VIDEO CAROUSEL ====== -->
 <div class="hero-carousel">
 
-  <p class="carousel-tagline">Taste a little sample of our content through these reels</p>
+  <p class="carousel-tagline">A small selection of our reels — follow for more!</p>
 
   <!-- Carousel viewport -->
   <div class="carousel-viewport">


### PR DESCRIPTION
## Summary
- Carousel tagline updated to encourage following ("A small selection of our reels — follow for more!")
- Mobile carousel height capped via max-height so tall/narrow screens don't stretch with empty space
- Carousel viewport padding tightened — removed redundant margin-top and per-slide padding
- Desktop side padding bumped slightly (32px → 42px) for breathing room