### PR TITLE
Fix play/pause controls and audio playback for carousel slides

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -182,14 +182,23 @@
         s.src = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client.min.js';
         s.onload = function() {
             try {
+                // Persist an anonymous user ID so Statsig can assign experiments
+                var uid = localStorage.getItem('rt-uid');
+                if (!uid) {
+                    uid = 'rt-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+                    localStorage.setItem('rt-uid', uid);
+                }
                 var SC = window.Statsig.StatsigClient;
-                var client = new SC(STATSIG_KEY, {});
-                client.initializeAsync();
-                window.__STATSIG_CLIENT__ = client;
+                var client = new SC(STATSIG_KEY, { userID: uid });
+                // Wait for initialization to complete before exposing the client
+                function onReady() {
+                    window.__STATSIG_CLIENT__ = client;
+                    if (window.__rtAnalytics) {
+                        window.__rtAnalytics.flushQueue();
+                    }
+                }
+                client.initializeAsync().then(onReady).catch(onReady);
             } catch(e) {}
-            if (window.__STATSIG_CLIENT__ && window.__rtAnalytics) {
-                window.__rtAnalytics.flushQueue();
-            }
         };
         document.head.appendChild(s);
     }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,20 @@
     ) {
         document.body.classList.add("mobile-device");
     }
+    // Detect in-app browsers (Instagram, Messenger, Facebook, TikTok, etc.)
+    if (/FBAN|FBAV|Instagram|Messenger|Line\/|Snapchat|Twitter|BytedanceWebview|TikTok/i.test(a)) {
+        document.body.classList.add("inapp-browser");
+        // Auto-remove "unsupported browser" banners injected by third-party scripts (e.g. YouTube)
+        new MutationObserver(function(mutations) {
+            mutations.forEach(function(m) {
+                m.addedNodes.forEach(function(n) {
+                    if (n.nodeType === 1 && n.textContent && /not (officially )?supported|unsupported browser/i.test(n.textContent) && !n.closest('.hero-carousel')) {
+                        n.remove();
+                    }
+                });
+            });
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
 })(navigator.userAgent||navigator.vendor||window.opera,'');
 </script>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,20 +27,6 @@
     ) {
         document.body.classList.add("mobile-device");
     }
-    // Detect in-app browsers (Instagram, Messenger, Facebook, TikTok, etc.)
-    if (/FBAN|FBAV|Instagram|Messenger|Line\/|Snapchat|Twitter|BytedanceWebview|TikTok/i.test(a)) {
-        document.body.classList.add("inapp-browser");
-        // Auto-remove "unsupported browser" banners injected by third-party scripts (e.g. YouTube)
-        new MutationObserver(function(mutations) {
-            mutations.forEach(function(m) {
-                m.addedNodes.forEach(function(n) {
-                    if (n.nodeType === 1 && n.textContent && /not (officially )?supported|unsupported browser/i.test(n.textContent) && !n.closest('.hero-carousel')) {
-                        n.remove();
-                    }
-                });
-            });
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
 })(navigator.userAgent||navigator.vendor||window.opera,'');
 </script>
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -67,7 +67,7 @@ body {
 .hero-carousel {
   position: relative;
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
   background: var(--flour) url('/assets/images/pattern_illustrations_flour.png');
   background-size: 300px;
   overflow: hidden;
@@ -1107,6 +1107,14 @@ body.mobile-device {
 }
 .mobile-device .carousel-viewport {
   padding: 56px 24px 12px;
+}
+
+/* In-app browsers: extra top space is eaten by injected banners, reduce padding */
+.mobile-device.inapp-browser .carousel-viewport {
+  padding-top: 48px;
+}
+.mobile-device.inapp-browser .carousel-tagline {
+  top: 46px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1106,15 +1106,7 @@ body.mobile-device {
   max-height: calc((100vw - 48px) * 16 / 9 + 120px);
 }
 .mobile-device .carousel-viewport {
-  padding: 56px 24px 12px;
-}
-
-/* In-app browsers: extra top space is eaten by injected banners, reduce padding */
-.mobile-device.inapp-browser .carousel-viewport {
-  padding-top: 48px;
-}
-.mobile-device.inapp-browser .carousel-tagline {
-  top: 46px;
+  padding: 56px 24px 54px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/index.md
+++ b/index.md
@@ -144,11 +144,11 @@ title: Home
           <div class="card-header">
             <h3 class="card-header-title">Join the Family</h3>
             <div class="card-header-controls">
-              <button class="card-ctrl ctrl-playpause is-paused" disabled aria-label="Play/Pause">
+              <button class="card-ctrl ctrl-playpause is-paused" data-slide="4" aria-label="Play/Pause">
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
               </button>
-              <button class="card-ctrl ctrl-speed" disabled aria-label="Playback speed">
+              <button class="card-ctrl ctrl-speed" data-slide="4" aria-label="Playback speed">
                 <span class="speed-label">1x</span>
               </button>
               <button class="card-ctrl card-mute is-muted" data-slide="4" aria-label="Toggle sound">
@@ -296,11 +296,11 @@ title: Home
           <div class="card-header">
             <h3 class="card-header-title">Join the Family</h3>
             <div class="card-header-controls">
-              <button class="card-ctrl ctrl-playpause is-paused" disabled aria-label="Play/Pause">
+              <button class="card-ctrl ctrl-playpause is-paused" data-slide="9" aria-label="Play/Pause">
                 <svg class="pp-pause" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
                 <svg class="pp-play" viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
               </button>
-              <button class="card-ctrl ctrl-speed" disabled aria-label="Playback speed">
+              <button class="card-ctrl ctrl-speed" data-slide="9" aria-label="Playback speed">
                 <span class="speed-label">1x</span>
               </button>
               <button class="card-ctrl card-mute is-muted" data-slide="9" aria-label="Toggle sound">
@@ -544,6 +544,7 @@ function onYouTubeIframeAPIReady() {
     if (prevEl && prevEl.classList.contains('carousel-slide-connect')) {
       var prevAudio = prevEl.querySelector('.connect-audio');
       if (prevAudio) prevAudio.pause();
+      slidePlaying[prevSlide] = false;
     }
 
     // Play new video (if it's a video slide)
@@ -577,7 +578,11 @@ function onYouTubeIframeAPIReady() {
       if (curAudio) {
         window._lastPlaySource = 'auto';
         curAudio.muted = globalMuted;
+        curAudio.playbackRate = globalSpeed;
         curAudio.play().then(function() {
+          slidePlaying[currentSlide] = true;
+          syncControls(currentSlide);
+          updatePulse(currentSlide);
           if (rt) rt.logEvent('playback_started', {
             slide: String(currentSlide),
             trigger: 'auto',
@@ -633,18 +638,38 @@ function onYouTubeIframeAPIReady() {
   document.querySelectorAll('.ctrl-playpause').forEach(function(btn) {
     btn.addEventListener('click', function() {
       var idx = parseInt(this.getAttribute('data-slide'));
+      var slideEl = slides[idx];
+      var isConnect = slideEl && slideEl.classList.contains('carousel-slide-connect');
+      var ca = isConnect ? slideEl.querySelector('.connect-audio') : null;
       var p = players[idx];
-      if (!p || !p.getPlayerState) return;
-      var state = p.getPlayerState();
-      if (state === YT.PlayerState.PLAYING) {
-        p.pauseVideo();
-        slidePlaying[idx] = false;
-        this.classList.add('is-paused');
-      } else {
-        window._lastPlaySource = 'user';
-        p.playVideo();
-        slidePlaying[idx] = true;
-        this.classList.remove('is-paused');
+
+      if (isConnect && ca) {
+        // Connect slide — toggle audio
+        if (!ca.paused) {
+          ca.pause();
+          slidePlaying[idx] = false;
+          this.classList.add('is-paused');
+        } else {
+          window._lastPlaySource = 'user';
+          ca.muted = globalMuted;
+          ca.playbackRate = globalSpeed;
+          ca.play().catch(function(){});
+          slidePlaying[idx] = true;
+          this.classList.remove('is-paused');
+        }
+      } else if (p && p.getPlayerState) {
+        // Video slide — toggle YouTube player
+        var state = p.getPlayerState();
+        if (state === YT.PlayerState.PLAYING) {
+          p.pauseVideo();
+          slidePlaying[idx] = false;
+          this.classList.add('is-paused');
+        } else {
+          window._lastPlaySource = 'user';
+          p.playVideo();
+          slidePlaying[idx] = true;
+          this.classList.remove('is-paused');
+        }
       }
       updatePulse(idx);
     });
@@ -723,6 +748,11 @@ function onYouTubeIframeAPIReady() {
         if (p && p.setPlaybackRate) {
           try { p.setPlaybackRate(globalSpeed); } catch(e) {}
         }
+      });
+
+      // Apply to all connect audio elements
+      document.querySelectorAll('.connect-audio').forEach(function(a) {
+        a.playbackRate = globalSpeed;
       });
 
       syncSpeedLabels();


### PR DESCRIPTION
## Summary
This PR fixes the play/pause and speed control functionality for carousel slides, particularly for "Connect" audio slides. It removes the `disabled` attribute from controls, adds proper data attributes, and implements complete audio playback handling with state synchronization.

## Key Changes

- **Removed `disabled` attribute** from play/pause and speed control buttons and replaced with `data-slide` attributes to enable functionality
- **Enhanced play/pause handler** to support both video slides (YouTube players) and audio slides (Connect slides) with appropriate branching logic
- **Added audio playback state management** including:
  - Setting `playbackRate` to match global speed setting when audio plays
  - Tracking playback state in `slidePlaying` array
  - Syncing UI controls and pulse indicators after audio starts
- **Fixed speed control** to apply playback rate to all active audio elements, not just video players
- **Improved Statsig initialization** in analytics to:
  - Persist anonymous user IDs in localStorage for consistent experiment assignment
  - Wait for client initialization before exposing it globally
  - Properly flush analytics queue after client is ready
- **Fixed viewport height** on mobile by changing from `100vh` to `100dvh` to account for dynamic viewport units
- **Adjusted mobile carousel padding** to accommodate proper spacing

## Implementation Details

The play/pause control now intelligently detects whether a slide contains audio or video and handles playback accordingly. Audio elements properly inherit global muted and speed settings, and all state changes trigger appropriate UI synchronization through `syncControls()` and `updatePulse()` functions.

https://claude.ai/code/session_014HrmH2fZemyD8NmB2JbzqH