### PR TITLE
Improve mobile UI and notch/safe area support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{{ page.title }} | {{ site.title }}</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -67,6 +67,7 @@ body {
 .hero-carousel {
   position: relative;
   width: 100%;
+  height: 100vh;
   height: 100dvh;
   background: var(--flour) url('/assets/images/pattern_illustrations_flour.png');
   background-size: 300px;
@@ -139,6 +140,7 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
+  z-index: 1;
 }
 
 .slide-video iframe {
@@ -432,6 +434,7 @@ body {
 .hero-controls {
   position: absolute;
   bottom: 0px;
+  bottom: env(safe-area-inset-bottom, 0px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 10;
@@ -1117,9 +1120,23 @@ body.mobile-device {
 .mobile-device .card-header { padding: 8px 10px; }
 .mobile-device .card-header-title { font-size: 13px; }
 .mobile-device .card-header-controls { gap: 6px; }
-.mobile-device .card-ctrl { width: 32px; height: 32px; }
-.mobile-device .card-ctrl svg { width: 14px; height: 14px; }
-.mobile-device .ctrl-speed { width: auto; min-width: 32px; padding: 0 7px; }
+.mobile-device .card-ctrl {
+  width: 36px;
+  height: 36px;
+  position: relative;
+  background: rgba(0, 0, 0, 0.7);
+}
+/* Expand touch target beyond visible button for easier tapping */
+.mobile-device .card-ctrl::after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+}
+.mobile-device .card-ctrl svg { width: 15px; height: 15px; }
+.mobile-device .ctrl-speed { width: auto; min-width: 36px; padding: 0 8px; }
 .mobile-device .speed-label { font-size: 10px; }
 .mobile-device .card-footer { padding: 8px 10px; }
 .mobile-device .card-footer-subtitle { font-size: 12px; }
@@ -1127,7 +1144,7 @@ body.mobile-device {
 
 /* Mobile: controls */
 .mobile-device .hero-controls {
-  bottom: 0px;
+  bottom: env(safe-area-inset-bottom, 0px);
   gap: 8px;
   padding: 8px 14px;
 }


### PR DESCRIPTION
## Summary
This PR enhances mobile device support by improving safe area handling for devices with notches/dynamic islands and increasing touch target sizes for better usability on mobile devices.

## Key Changes
- **Safe area inset support**: Added `viewport-fit=cover` to viewport meta tag and updated `.hero-controls` and `.mobile-device .hero-controls` to use `env(safe-area-inset-bottom)` for proper positioning on devices with notches or home indicators
- **Improved touch targets**: Increased `.mobile-device .card-ctrl` button size from 32px to 36px with a semi-transparent dark background, and added a `::after` pseudo-element to expand the clickable area by 4px on all sides for easier tapping
- **Visual refinements**: 
  - Increased SVG icon size within buttons from 14px to 15px
  - Updated `.ctrl-speed` min-width from 32px to 36px with adjusted padding
  - Added z-index to `.slide-video` container for proper layering
  - Added fallback `height: 100vh` before `height: 100dvh` for better browser compatibility

## Implementation Details
- The `::after` pseudo-element on `.card-ctrl` creates an invisible expanded touch target without affecting the visual button size, improving accessibility on mobile devices
- Safe area insets use CSS `env()` with fallback values to gracefully degrade on browsers that don't support notch-aware layouts
- The viewport-fit change allows content to extend into safe areas, which is then properly managed with the inset values

https://claude.ai/code/session_01STjCRuHe8dqsRx6XitGDsc