### PR TITLE
Push mobile carousel card below tagline and Follow button

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{{ page.title }} | {{ site.title }}</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -67,6 +67,7 @@ body {
 .hero-carousel {
   position: relative;
   width: 100%;
+  height: 100vh;
   height: 100dvh;
   background: var(--flour) url('/assets/images/pattern_illustrations_flour.png');
   background-size: 300px;
@@ -139,6 +140,7 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
+  z-index: 1;
 }
 
 .slide-video iframe {
@@ -432,6 +434,7 @@ body {
 .hero-controls {
   position: absolute;
   bottom: 0px;
+  bottom: env(safe-area-inset-bottom, 0px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 10;
@@ -1117,9 +1120,23 @@ body.mobile-device {
 .mobile-device .card-header { padding: 8px 10px; }
 .mobile-device .card-header-title { font-size: 13px; }
 .mobile-device .card-header-controls { gap: 6px; }
-.mobile-device .card-ctrl { width: 32px; height: 32px; }
-.mobile-device .card-ctrl svg { width: 14px; height: 14px; }
-.mobile-device .ctrl-speed { width: auto; min-width: 32px; padding: 0 7px; }
+.mobile-device .card-ctrl {
+  width: 36px;
+  height: 36px;
+  position: relative;
+  background: rgba(0, 0, 0, 0.7);
+}
+/* Expand touch target beyond visible button for easier tapping */
+.mobile-device .card-ctrl::after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+}
+.mobile-device .card-ctrl svg { width: 15px; height: 15px; }
+.mobile-device .ctrl-speed { width: auto; min-width: 36px; padding: 0 8px; }
 .mobile-device .speed-label { font-size: 10px; }
 .mobile-device .card-footer { padding: 8px 10px; }
 .mobile-device .card-footer-subtitle { font-size: 12px; }
@@ -1127,7 +1144,7 @@ body.mobile-device {
 
 /* Mobile: controls */
 .mobile-device .hero-controls {
-  bottom: 0px;
+  bottom: env(safe-area-inset-bottom, 0px);
   gap: 8px;
   padding: 8px 14px;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1106,10 +1106,10 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {
-  max-height: calc((100vw - 48px) * 16 / 9 + 120px);
+  max-height: calc((100vw - 48px) * 16 / 9 + 158px);
 }
 .mobile-device .carousel-viewport {
-  padding: 56px 24px 54px;
+  padding: 94px 24px 54px;
 }
 .mobile-device .slide-card {
   height: auto;


### PR DESCRIPTION
Carousel viewport top padding increased from 56px to 94px so the card clears the tagline and Follow button on mobile web and in-app browsers (Messenger, Instagram, etc.)
max-height calc adjusted (120px → 158px) to compensate so the card keeps its size
