### PR TITLE
Increase mobile carousel top padding to clear tagline on all browsers

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1106,10 +1106,10 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {
-  max-height: calc((100vw - 48px) * 16 / 9 + 158px);
+  max-height: calc((100vw - 48px) * 16 / 9 + 184px);
 }
 .mobile-device .carousel-viewport {
-  padding: 94px 24px 54px;
+  padding: 120px 24px 54px;
 }
 .mobile-device .slide-card {
   height: auto;


### PR DESCRIPTION
The Kufam font renders wider on Chrome/in-app browsers than Safari, causing the tagline (max-width: 50vw, white-space: normal) to wrap to 3 lines on narrow screens. This pushed the tagline bottom to ~114px, beyond the previous 94px viewport padding. Increase to 120px to clear the tagline and Follow button across all mobile browsers. Adjust max-height calc accordingly (158px → 184px) to preserve card size.

https://claude.ai/code/session_01STjCRuHe8dqsRx6XitGDsc