### PR TITLE
Move cookie consent from modal to footer banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -255,11 +255,8 @@
         }
     }
 
-    // Auto-open follow popup on first visit
-    if (!localStorage.getItem('follow-popup-shown')) {
-        openPopup('page-load');
-        localStorage.setItem('follow-popup-shown', '1');
-    }
+    // Auto-open follow popup on every page load
+    openPopup('page-load');
 
     // Open triggers — "Follow" buttons
     document.querySelectorAll('.platform-trigger').forEach(function(el) {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -128,37 +128,29 @@
 
     {% include footer.html %}
 
-<!-- ====== TWO-STEP MODAL: COOKIES → FOLLOW ====== -->
+<!-- ====== FOLLOW MODAL ====== -->
 <div class="platform-overlay" id="platform-popup">
   <div class="platform-modal">
     <button class="platform-close" id="platform-close" type="button">&times;</button>
-
-    <!-- Step 1: Cookie consent -->
-    <div class="modal-step is-active" id="step-cookie">
-      <div class="cookie-step-icon">&#127850;</div>
-      <h3 class="cookie-step-title">Before you dig in&hellip;</h3>
-      <p class="cookie-step-text">We use cookies &amp; analytics to improve your RotiTales experience.</p>
-      <p class="cookie-step-aside">No personal data is sold&mdash;ever.</p>
-      <div class="cookie-step-buttons">
-        <button class="cookie-step-accept" id="cookie-accept">Accept Cookies</button>
-        <button class="cookie-step-decline" id="cookie-decline">No Thanks</button>
+    <div class="platform-header">
+      <img src="/assets/images/rotitales_roti_on_fire_logo.png" alt="Roti Tales" class="platform-logo" />
+      <div class="platform-brand">
+        <h3 class="platform-heading">Roti Tales</h3>
+        <p class="platform-tagline">Follow to keep eating healthy rotis!</p>
       </div>
     </div>
-
-    <!-- Step 2: Follow -->
-    <div class="modal-step" id="step-follow">
-      <div class="platform-header">
-        <img src="/assets/images/rotitales_roti_on_fire_logo.png" alt="Roti Tales" class="platform-logo" />
-        <div class="platform-brand">
-          <h3 class="platform-heading">Roti Tales</h3>
-          <p class="platform-tagline">Follow to keep eating healthy rotis!</p>
-        </div>
-      </div>
-      <div class="platform-row">
-        {% include social-links.html class="social-link" source="popup" %}
-      </div>
+    <div class="platform-row">
+      {% include social-links.html class="social-link" source="popup" %}
     </div>
+  </div>
+</div>
 
+<!-- ====== COOKIE CONSENT FOOTER BANNER ====== -->
+<div class="cookie-banner" id="cookie-banner">
+  <p class="cookie-banner-text">We use cookies &amp; analytics to improve your experience. No data is sold&mdash;ever.</p>
+  <div class="cookie-banner-buttons">
+    <button class="cookie-banner-accept" id="cookie-accept">Accept</button>
+    <button class="cookie-banner-decline" id="cookie-decline">Decline</button>
   </div>
 </div>
 
@@ -167,30 +159,31 @@
     var STATSIG_KEY = 'client-XBaeJ6hvk0nI45w5ERTiznvlzNfA2QcYdXAC6VFg29e';
     var popup = document.getElementById('platform-popup');
     var closeBtn = document.getElementById('platform-close');
-    var stepCookie = document.getElementById('step-cookie');
-    var stepFollow = document.getElementById('step-follow');
+    var banner = document.getElementById('cookie-banner');
     var btnAccept = document.getElementById('cookie-accept');
     var btnDecline = document.getElementById('cookie-decline');
     if (!popup) return;
 
     var rt = window.__rtAnalytics;
     var consent = localStorage.getItem('cookie-ok');
-    var needsCookieConsent = (consent !== '1' && consent !== 'declined');
 
+    // --- Statsig: always load, userID only if consent accepted ---
     function loadStatsig() {
         var s = document.createElement('script');
         s.src = 'https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client.min.js';
         s.onload = function() {
             try {
-                // Persist an anonymous user ID so Statsig can assign experiments
-                var uid = localStorage.getItem('rt-uid');
-                if (!uid) {
-                    uid = 'rt-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
-                    localStorage.setItem('rt-uid', uid);
+                var user = {};
+                if (consent === '1') {
+                    var uid = localStorage.getItem('rt-uid');
+                    if (!uid) {
+                        uid = 'rt-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+                        localStorage.setItem('rt-uid', uid);
+                    }
+                    user.userID = uid;
                 }
                 var SC = window.Statsig.StatsigClient;
-                var client = new SC(STATSIG_KEY, { userID: uid });
-                // Wait for initialization to complete before exposing the client
+                var client = new SC(STATSIG_KEY, user);
                 function onReady() {
                     window.__STATSIG_CLIENT__ = client;
                     if (window.__rtAnalytics) {
@@ -203,29 +196,41 @@
         document.head.appendChild(s);
     }
 
-    // Load Statsig immediately if already accepted
-    if (consent === '1') {
-        loadStatsig();
+    // Always load Statsig — anonymous unless consent accepted
+    loadStatsig();
+
+    // --- Cookie banner: show if no decision yet ---
+    function hideBanner() {
+        if (banner) banner.classList.add('is-hidden');
     }
 
-    // Show a specific step
-    function showStep(step) {
-        stepCookie.classList.remove('is-active');
-        stepFollow.classList.remove('is-active');
-        step.classList.add('is-active');
+    if (consent === '1' || consent === 'declined') {
+        hideBanner();
     }
 
-    // Transition from cookie step to follow step
-    function goToFollow() {
-        showStep(stepFollow);
-    }
-
-    function openPopup(trigger, skipToFollow) {
-        if (skipToFollow) {
-            showStep(stepFollow);
-        } else {
-            showStep(stepCookie);
+    if (btnAccept) btnAccept.addEventListener('click', function() {
+        localStorage.setItem('cookie-ok', '1');
+        consent = '1';
+        hideBanner();
+        // Upgrade Statsig with userID: reinitialize
+        if (window.__STATSIG_CLIENT__) {
+            var uid = localStorage.getItem('rt-uid');
+            if (!uid) {
+                uid = 'rt-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+                localStorage.setItem('rt-uid', uid);
+            }
+            try { window.__STATSIG_CLIENT__.updateUserAsync({ userID: uid }); } catch(e) {}
         }
+    });
+
+    if (btnDecline) btnDecline.addEventListener('click', function() {
+        localStorage.setItem('cookie-ok', 'declined');
+        consent = 'declined';
+        hideBanner();
+    });
+
+    // --- Follow popup (fully independent of cookies) ---
+    function openPopup(trigger) {
         popup.classList.add('is-open');
         document.body.style.overflow = 'hidden';
         if (rt) {
@@ -241,13 +246,6 @@
         if (!popup.classList.contains('is-open')) return;
         popup.classList.remove('is-open');
         document.body.style.overflow = '';
-
-        // If user closes during cookie step without deciding, treat as declined
-        if (needsCookieConsent && stepCookie.classList.contains('is-active')) {
-            localStorage.setItem('cookie-ok', 'declined');
-            needsCookieConsent = false;
-        }
-
         if (rt) {
             var openedAt = rt.popupOpenedAt();
             rt.logEvent('follow_popup_closed', {
@@ -257,31 +255,19 @@
         }
     }
 
-    // Cookie buttons → record decision, advance to follow step
-    if (btnAccept) btnAccept.addEventListener('click', function() {
-        localStorage.setItem('cookie-ok', '1');
-        needsCookieConsent = false;
-        loadStatsig();
-        goToFollow();
-    });
-    if (btnDecline) btnDecline.addEventListener('click', function() {
-        localStorage.setItem('cookie-ok', 'declined');
-        needsCookieConsent = false;
-        goToFollow();
-    });
-
-    // Auto-open on page load if cookie consent is needed
-    if (needsCookieConsent) {
-        openPopup('page-load', false);
+    // Auto-open follow popup on first visit
+    if (!localStorage.getItem('follow-popup-shown')) {
+        openPopup('page-load');
+        localStorage.setItem('follow-popup-shown', '1');
     }
 
-    // Open triggers — "Follow" buttons (skip to follow step if consent decided)
+    // Open triggers — "Follow" buttons
     document.querySelectorAll('.platform-trigger').forEach(function(el) {
         el.addEventListener('click', function(e) {
             e.preventDefault();
             e.stopPropagation();
             var trigger = el.id === 'nav-follow' ? 'nav' : 'mission';
-            openPopup(trigger, !needsCookieConsent);
+            openPopup(trigger);
         });
     });
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -684,89 +684,70 @@ body {
   height: 20px;
 }
 
-/* ===== TWO-STEP MODAL (cookie → follow) ===== */
-.modal-step {
-  display: none;
-}
-
-.modal-step.is-active {
-  display: block;
-  animation: stepFadeIn 0.3s ease-out;
-}
-
-@keyframes stepFadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-/* Cookie step — dark warmth bg matching production cookie modal */
-#step-cookie {
+/* ===== COOKIE CONSENT FOOTER BANNER ===== */
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
   background: var(--warmth);
-  border-radius: 18px;
-  padding: 32px 28px;
-  margin: -36px -28px -32px;
   color: var(--flour);
-}
-
-.cookie-step-icon {
-  font-size: 44px;
-  margin-bottom: 8px;
-}
-
-.cookie-step-title {
   font-family: 'Kufam', sans-serif;
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--wheat);
-  margin: 0 0 12px;
-}
-
-.cookie-step-text {
-  font-family: 'Kufam', sans-serif;
-  font-size: 14px;
-  line-height: 1.55;
-  color: var(--flour);
-  opacity: 0.9;
-  margin: 0 0 8px;
-}
-
-.cookie-step-aside {
-  font-family: 'Kufam', sans-serif;
-  font-size: 12px;
-  color: var(--wheat-light);
-  margin: 0 0 22px;
-}
-
-.cookie-step-buttons {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 12px 20px;
+  box-shadow: 0 -4px 20px color-mix(in srgb, black 30%, transparent);
+  transform: translateY(0);
+  transition: transform 0.35s ease;
 }
 
-.cookie-step-accept,
-.cookie-step-decline {
+.cookie-banner.is-hidden {
+  transform: translateY(100%);
+  pointer-events: none;
+}
+
+.cookie-banner-text {
+  font-size: 13px;
+  line-height: 1.4;
+  margin: 0;
+  opacity: 0.92;
+  flex: 1;
+  max-width: 520px;
+}
+
+.cookie-banner-buttons {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cookie-banner-accept,
+.cookie-banner-decline {
   border: none;
   font-family: 'Kufam', sans-serif;
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 700;
-  padding: 12px 20px;
-  border-radius: 12px;
+  padding: 8px 16px;
+  border-radius: 8px;
   cursor: pointer;
-  transition: opacity 0.2s, transform 0.15s;
+  transition: opacity 0.2s;
+  white-space: nowrap;
 }
 
-.cookie-step-accept:hover,
-.cookie-step-decline:hover {
+.cookie-banner-accept:hover,
+.cookie-banner-decline:hover {
   opacity: 0.85;
-  transform: scale(1.02);
 }
 
-.cookie-step-accept {
+.cookie-banner-accept {
   background: var(--wheat);
   color: var(--warmth);
 }
 
-.cookie-step-decline {
+.cookie-banner-decline {
   background: transparent;
   color: var(--flour);
   border: 1px solid var(--flour);
@@ -951,13 +932,6 @@ body {
   color: var(--clay);
 }
 
-/* Close button on dark cookie step */
-.platform-modal:has(#step-cookie.is-active) > .platform-close {
-  color: var(--wheat-light);
-}
-.platform-modal:has(#step-cookie.is-active) > .platform-close:hover {
-  color: var(--flour);
-}
 
 /* Header: logo + title side by side */
 .platform-header {
@@ -1175,9 +1149,6 @@ body.mobile-device {
 .mobile-device .platform-logo { width: 60px; height: 60px; }
 .mobile-device .platform-heading { font-size: 22px; }
 .mobile-device .platform-row { gap: 8px; }
-
-/* Mobile: cookie step */
-.mobile-device #step-cookie { padding: 28px 20px 24px; margin: -28px -20px -24px; }
 
 /* Mobile: follow button — fixed, right side, below nav, shares row with tagline */
 .mobile-device .nav-follow {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1106,10 +1106,10 @@ body.mobile-device {
 
 /* Mobile: carousel */
 .mobile-device .hero-carousel {
-  max-height: calc((100vw - 48px) * 16 / 9 + 158px);
+  max-height: calc((100vw - 48px) * 16 / 9 + 184px);
 }
 .mobile-device .carousel-viewport {
-  padding: 94px 24px 54px;
+  padding: 120px 24px 54px;
 }
 .mobile-device .slide-card {
   height: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -690,7 +690,7 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 9999;
+  z-index: 10001;
   background: var(--warmth);
   color: var(--flour);
   font-family: 'Kufam', sans-serif;


### PR DESCRIPTION
Summary
Decoupled cookie consent from the follow popup — follow modal now opens immediately on first visit
Cookie consent moved to a non-blocking footer banner users can interact with in parallel
Statsig always loads: events include userID if accepted, fire anonymously if declined/ignored